### PR TITLE
Fix ansible-lint warnings

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,7 +1,0 @@
----
-
-skip_list:
-  - name[casing]
-  - name[template]
-  - role-name
-  - var-naming[no-role-prefix]

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.venv/
 .vscode/
 tasks/test.json

--- a/.yamllint
+++ b/.yamllint
@@ -1,7 +1,0 @@
----
-extends: default
-
-rules:
-  line-length:
-    max: 160
-    level: warning

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 galaxy_info:
   role_name: sync_dir_from_other_host
+  namespace: rompe
   author: Ulf Rompe
   description: Keep a file or directory in sync with another ansible-managed host
   license: MIT


### PR DESCRIPTION
- Remove `.yamllint` config since `ansible-lint` doesn't like it
- Explicitly state namespace
- Add .venv to `.gitignore`
- Remove now unneeded `.ansible-lint` config as well.